### PR TITLE
Postgres SQL via docker-comose

### DIFF
--- a/db/postgres/docker-compose.yml
+++ b/db/postgres/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.1'
+
+services:
+
+  db:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: example
+
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080

--- a/db/postgres/docker-compose.yml
+++ b/db/postgres/docker-compose.yml
@@ -6,7 +6,12 @@ services:
     image: postgres
     restart: always
     environment:
-      POSTGRES_PASSWORD: example
+      POSTGRES_USER: backtorl
+      POSTGRES_PASSWORD: backtorl
+      PGDATA: /var/lib/postgresql/data/mydata
+    volumes:
+      - ./postgresql-data:/var/lib/postgresql/data/mydata
+
 
   adminer:
     image: adminer


### PR DESCRIPTION
Added a docker-compose to quickly start a Postgres DB. It's setup in a way that it saves the database local, so updates made during tests preserve.
Later on the database will have all needed tables initialised on the first run.

Login for now is 
```
User: backtorl
Password: backtorl
```
running on `localhost:8080`